### PR TITLE
Remove prereq on XSConfig

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Mock-Config
 
+        Remove prereq on XSConfig
+
 0.02    2016-02-28 18:35:44 rurban
         Fixed for PP Config
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,9 +30,9 @@ WriteMakefile(
   },
   ($ExtUtils::MakeMaker::VERSION gt '6.46' ?
    ('META_MERGE' =>
-    {"recommends" =>
+    {suggests =>
      {
-       'XSConfig' => '0.19',
+       'XSConfig' => '6.19',
      },
      resources =>
      {


### PR DESCRIPTION
Installing Mock-Config from CPAN.pm shouldn't install XSConfig. Fixing this
will encourage widespread usage of Mock-Config in very popular modules on
CPAN.
